### PR TITLE
Update vite config for Tauri compatibility and debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@tauri-apps/cli": "^1.5.8",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@types/node": "^20.10.7",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react": "^4.2.1",
@@ -1367,6 +1368,15 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.7.tgz",
+      "integrity": "sha512-fRbIKb8C/Y2lXxB5eVMj4IU7xpdox0Lh8bUPEdtLysaylsml1hOOx1+STloRs/B9nf7C6kPRmmg/V7aQW7usNg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/prop-types": {
@@ -3055,6 +3065,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@tauri-apps/cli": "^1.5.8",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/node": "^20.10.7",
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^4.2.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,22 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig } from 'vite'
 
-// https://vitejs.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig({
   plugins: [react()],
-
+  // prevent vite from obscuring rust errors
   clearScreen: false,
-
+  // Tauri expects a fixed port, fail if that port is not available
   server: {
-    port: 1420,
     strictPort: true,
-    watch: {
-      ignored: ["**/src-tauri/**"],
-    },
   },
-}));
+  // to access the Tauri environment variables set by the CLI with information about the current target
+  envPrefix: ['VITE_', 'TAURI_PLATFORM', 'TAURI_ARCH', 'TAURI_FAMILY', 'TAURI_PLATFORM_VERSION', 'TAURI_PLATFORM_TYPE', 'TAURI_DEBUG'],
+  build: {
+    // Tauri uses Chromium on Windows and WebKit on macOS and Linux
+    target: process.env.TAURI_PLATFORM == 'windows' ? 'chrome105' : 'safari13',
+    // don't minify for debug builds
+    minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
+    // produce sourcemaps for debug builds
+    sourcemap: !!process.env.TAURI_DEBUG,
+  },
+})


### PR DESCRIPTION
- Import and configure @vitejs/plugin-react for React support
- Set clearScreen to false to prevent obscuring Rust errors
- Enforce strictPort for consistent server port
- Add envPrefix for Tauri environment variables
- Set build target based on TAURI_PLATFORM
- Configure minify and sourcemap settings for debug builds