### PR TITLE
Render cell execution errors in the UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "lint": "eslint .",
-    "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format": "prettier --write src",
+    "format:check": "prettier --check src"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.4",

--- a/src/ui/Notebook.ts
+++ b/src/ui/Notebook.ts
@@ -131,10 +131,11 @@ export class Notebook {
     try {
       const onEvent = new Channel<RunCellEvent>();
       let output = "";
+      let status: NotebookOutput['status'] = "success";
       let displays: Record<string, any> = {};
       const update = () =>
         this.state.setOutput(cellId, {
-          status: "success",
+          status,
           output,
           displays,
         });
@@ -143,6 +144,10 @@ export class Notebook {
       onEvent.onmessage = (message: RunCellEvent) => {
         if (message.event === "stdout" || message.event === "stderr") {
           output += message.data;
+          update();
+        } else if (message.event === "error") {
+          status = "error";
+          output += `${message.data.ename}: ${message.data.evalue}\n`;
           update();
         } else if (message.event === "execute_result") {
           // This means that there was a return value for the cell.
@@ -182,7 +187,7 @@ export class Notebook {
       };
 
       await invoke("run_cell", { kernelId: this.kernelId, code, onEvent });
-      this.state.setOutput(cellId, { status: "success", output, displays });
+      this.state.setOutput(cellId, { status, output, displays });
     } catch (error: any) {
       this.state.setOutput(cellId, {
         status: "error",

--- a/src/ui/Notebook.ts
+++ b/src/ui/Notebook.ts
@@ -131,7 +131,7 @@ export class Notebook {
     try {
       const onEvent = new Channel<RunCellEvent>();
       let output = "";
-      let status: NotebookOutput['status'] = "success";
+      let status: NotebookOutput["status"] = "success";
       let displays: Record<string, any> = {};
       const update = () =>
         this.state.setOutput(cellId, {


### PR DESCRIPTION
This change catches error messages in the UI and renders them. Note that there's a traceback available, but it's ANSI-encoded so I'm not introducing that for now. There doesn't seem to be a good ANSI decoder readily available, and this is something that'll probably be core to Jute (e.g. any time you run a command with `!...`, the output will be ANSI-encoded), so I'm saving that for a follow-up.

<img width="1473" alt="Screenshot 2025-01-01 at 7 10 16 PM" src="https://github.com/user-attachments/assets/61bbc42f-5134-4180-808d-8f7196af0635" />
