### PR TITLE
Show kernel status (currently yellow/red) when opening a notebook

### DIFF
--- a/src/pages/NotebookPage.tsx
+++ b/src/pages/NotebookPage.tsx
@@ -1,17 +1,40 @@
+import { useEffect, useMemo } from "react";
 import { useSearch } from "wouter";
 
+import { Notebook, NotebookContext } from "@/stores/notebook";
 import NotebookFooter from "@/ui/notebook/NotebookFooter";
 import NotebookHeader from "@/ui/notebook/NotebookHeader";
 import NotebookView from "@/ui/notebook/NotebookView";
 
 export default function NotebookPage() {
   const { path } = Object.fromEntries(new URLSearchParams(useSearch()));
+  // Single mutable object that is shared between all parts of the notebook.
+  const notebook = useMemo(() => new Notebook(path), [path]);
+
+  useEffect(() => {
+    notebook.addCell(`print("Hello, world!")`);
+    notebook.addCell(`for i in range(100):
+    if i % 15 == 0:
+        print("FizzBuzz")
+    elif i % 3 == 0:
+        print("Fizz")
+    elif i % 5 == 0:
+        print("Buzz")
+    else:
+        print(i)`);
+    notebook.addCell(`import matplotlib.pyplot as plt
+import numpy as np
+
+plt.plot(np.random.normal(size=(400,)).cumsum())`);
+  }, [notebook]);
 
   return (
     <main className="absolute inset-0 bg-white">
-      <NotebookHeader kernelName="Local Kernel (Python 3.11.7)" />
-      <NotebookView path={path} />
-      <NotebookFooter />
+      <NotebookContext.Provider value={notebook}>
+        <NotebookHeader kernelName="Local Kernel (Python 3.11.7)" />
+        <NotebookView />
+        <NotebookFooter />
+      </NotebookContext.Provider>
     </main>
   );
 }

--- a/src/stores/notebook.ts
+++ b/src/stores/notebook.ts
@@ -47,6 +47,7 @@ export type NotebookStoreState = {
       output?: NotebookOutput;
     };
   };
+  kernelId?: string;
 };
 
 export type NotebookOutput = {
@@ -70,9 +71,6 @@ type CellHandle = {
 };
 
 export class Notebook {
-  /** ID of the running kernel, populated after the kernel is started. */
-  kernelId: string;
-
   /** Promise that resolves when the kernel is started. */
   kernelStartPromise: Promise<void>;
 
@@ -99,13 +97,9 @@ export class Notebook {
     this.filename = parts.pop()!;
     this.directory = parts.join("/");
 
-    this.kernelId = "";
-    this.kernelStartPromise = (async () => {
-      this.kernelId = await invoke("start_kernel", { specName: "python3" });
-    })();
-
     this.store = createStore<NotebookStore>()(
       immer<NotebookStore>((set) => ({
+        kernelId: "",
         cellIds: [],
         cells: {},
 
@@ -123,12 +117,26 @@ export class Notebook {
           }),
       })),
     );
+
     this.refs = new Map();
+
+    this.kernelStartPromise = this.startKernel();
   }
 
   get state() {
     // Helper function, used internally to get the current notebook store state.
     return this.store.getState();
+  }
+
+  get kernelId() {
+    return this.state.kernelId;
+  }
+
+  async startKernel() {
+    const kernelId = await invoke<string>("start_kernel", {
+      specName: "python3",
+    });
+    this.store.setState({ kernelId });
   }
 
   addCell(initialText: string): string {

--- a/src/stores/notebook.ts
+++ b/src/stores/notebook.ts
@@ -47,6 +47,8 @@ export type NotebookStoreState = {
       output?: NotebookOutput;
     };
   };
+
+  /** ID of the running kernel, populated after the kernel is started. */
   kernelId?: string;
 };
 
@@ -99,7 +101,7 @@ export class Notebook {
 
     this.store = createStore<NotebookStore>()(
       immer<NotebookStore>((set) => ({
-        kernelId: "",
+        kernelId: undefined,
         cellIds: [],
         cells: {},
 

--- a/src/ui/notebook/NotebookHeader.tsx
+++ b/src/ui/notebook/NotebookHeader.tsx
@@ -1,5 +1,7 @@
+import clsx from "clsx";
 import {
   ChartLineIcon,
+  DotIcon,
   HomeIcon,
   PlayIcon,
   PlusIcon,
@@ -7,12 +9,19 @@ import {
   SettingsIcon,
 } from "lucide-react";
 import { Link } from "wouter";
+import { useStore } from "zustand";
+
+import { useNotebook } from "@/stores/notebook";
 
 type Props = {
   kernelName: string;
 };
 
 export default function NotebookHeader({ kernelName }: Props) {
+  const notebook = useNotebook();
+
+  const kernelId = useStore(notebook.store, (state) => state.kernelId);
+
   return (
     <div className="absolute inset-x-0 h-16 bg-gradient-to-b from-white/85 from-40% to-white/0">
       <header
@@ -31,8 +40,16 @@ export default function NotebookHeader({ kernelName }: Props) {
             <RefreshCwIcon size={16} />
           </button>
 
-          <button className="mx-2 w-60 rounded border border-gray-200 py-[3px] text-xs text-gray-900 transition-all hover:border-gray-400 hover:bg-gray-100 active:scale-105">
+          <button className="mx-2 flex w-60 items-center justify-center rounded border border-gray-200 py-[3px] text-xs text-gray-900 transition-all hover:border-gray-400 hover:bg-gray-100 active:scale-105">
+            <DotIcon
+              className={clsx(
+                "w-6",
+                kernelId === "" ? "text-orange-500" : "text-green-500",
+              )}
+            />
             {kernelName}
+            <div className="w-6" />{" "}
+            {/* Same width as the icon to make sure kernel name is center aligned */}
           </button>
 
           <button className="rounded p-1 text-gray-500 transition-all hover:bg-gray-100 hover:text-black active:scale-110">

--- a/src/ui/notebook/NotebookHeader.tsx
+++ b/src/ui/notebook/NotebookHeader.tsx
@@ -1,7 +1,6 @@
 import clsx from "clsx";
 import {
   ChartLineIcon,
-  DotIcon,
   HomeIcon,
   PlayIcon,
   PlusIcon,
@@ -41,15 +40,13 @@ export default function NotebookHeader({ kernelName }: Props) {
           </button>
 
           <button className="mx-2 flex w-60 items-center justify-center rounded border border-gray-200 py-[3px] text-xs text-gray-900 transition-all hover:border-gray-400 hover:bg-gray-100 active:scale-105">
-            <DotIcon
+            <div
               className={clsx(
-                "w-6",
-                kernelId === "" ? "text-orange-500" : "text-green-500",
+                "mr-2 h-2 w-2 rounded-full",
+                kernelId ? "bg-green-500" : "bg-orange-500",
               )}
             />
             {kernelName}
-            <div className="w-6" />{" "}
-            {/* Same width as the icon to make sure kernel name is center aligned */}
           </button>
 
           <button className="rounded p-1 text-gray-500 transition-all hover:bg-gray-100 hover:text-black active:scale-110">

--- a/src/ui/notebook/NotebookView.tsx
+++ b/src/ui/notebook/NotebookView.tsx
@@ -1,50 +1,24 @@
-import { useEffect, useMemo } from "react";
-
-import { Notebook, NotebookContext } from "@/stores/notebook";
+import { useNotebook } from "@/stores/notebook";
 
 import NotebookCells from "./NotebookCells";
 import NotebookLocation from "./NotebookLocation";
 
-type Props = {
-  path: string;
-};
-
-export default function NotebookView({ path }: Props) {
-  // Single mutable object that is shared between all parts of the notebook.
-  const notebook = useMemo(() => new Notebook(path), [path]);
-
-  useEffect(() => {
-    notebook.addCell(`print("Hello, world!")`);
-    notebook.addCell(`for i in range(100):
-    if i % 15 == 0:
-        print("FizzBuzz")
-    elif i % 3 == 0:
-        print("Fizz")
-    elif i % 5 == 0:
-        print("Buzz")
-    else:
-        print(i)`);
-    notebook.addCell(`import matplotlib.pyplot as plt
-import numpy as np
-
-plt.plot(np.random.normal(size=(400,)).cumsum())`);
-  }, [notebook]);
+export default function NotebookView() {
+  const notebook = useNotebook();
 
   return (
-    <NotebookContext.Provider value={notebook}>
-      <div className="grid h-full grid-cols-[1fr,200px] overflow-y-auto">
-        <div className="min-w-0 py-16">
-          <NotebookLocation
-            directory={notebook.directory}
-            filename={notebook.filename}
-          />
-          <NotebookCells />
-        </div>
-        <div
-          className="border-l border-gray-200 bg-gray-100"
-          data-tauri-drag-region
+    <div className="grid h-full grid-cols-[1fr,200px] overflow-y-auto">
+      <div className="min-w-0 py-16">
+        <NotebookLocation
+          directory={notebook.directory}
+          filename={notebook.filename}
         />
+        <NotebookCells />
       </div>
-    </NotebookContext.Provider>
+      <div
+        className="border-l border-gray-200 bg-gray-100"
+        data-tauri-drag-region
+      />
+    </div>
   );
 }


### PR DESCRIPTION
This adds a status indicator to each notebook with the state of the kernel. This shows why things may not be immediately executable, and we can eventually evolve this to include "red" statuses if there's something wrong.

"yellow" status, kernel is starting
<img width="1072" alt="Screenshot 2025-01-04 at 1 42 13 PM" src="https://github.com/user-attachments/assets/208cacd0-7c46-42a6-bc04-ee0fd852ad17" />

"green" status, kernel is ready
<img width="1072" alt="Screenshot 2025-01-04 at 1 42 18 PM" src="https://github.com/user-attachments/assets/9432261a-9851-4b51-83dc-62aa1519356a" />
