### PR TITLE
First pass at an open notebook implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@codemirror/view": "^6.36.1",
         "@fontsource-variable/fira-code": "^5.1.1",
         "@tauri-apps/api": "^2.1.1",
+        "@tauri-apps/plugin-dialog": "^2.2.0",
+        "@tauri-apps/plugin-fs": "^2.2.0",
         "clsx": "^2.1.1",
         "html-entities": "^2.5.2",
         "immer": "^10.1.1",
@@ -1748,6 +1750,22 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.2.0.tgz",
+      "integrity": "sha512-6bLkYK68zyK31418AK5fNccCdVuRnNpbxquCl8IqgFByOgWFivbiIlvb79wpSXi0O+8k8RCSsIpOquebusRVSg==",
+      "dependencies": {
+        "@tauri-apps/api": "^2.0.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-fs": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.2.0.tgz",
+      "integrity": "sha512-+08mApuONKI8/sCNEZ6AR8vf5vI9DXD4YfrQ9NQmhRxYKMLVhRW164vdW5BSLmMpuevftpQ2FVoL9EFkfG9Z+g==",
+      "dependencies": {
+        "@tauri-apps/api": "^2.0.0"
       }
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@codemirror/view": "^6.36.1",
     "@fontsource-variable/fira-code": "^5.1.1",
     "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/plugin-dialog": "^2.2.0",
+    "@tauri-apps/plugin-fs": "^2.2.0",
     "clsx": "^2.1.1",
     "html-entities": "^2.5.2",
     "immer": "^10.1.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -63,6 +63,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "ashpd"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43c03d9e36dd40cab48435be0b09646da362c278223ca535493877b2c1dee9"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.8.5",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +107,90 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+ "tracing",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.94",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -121,6 +238,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -192,6 +315,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -655,6 +791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +853,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +883,12 @@ dependencies = [
  "quote",
  "syn 2.0.94",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -799,6 +961,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.94",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,12 +1005,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -988,6 +1177,19 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1373,6 +1575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1929,8 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-shell",
  "thiserror 1.0.57",
  "time",
@@ -1793,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
@@ -1829,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -2001,6 +2211,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,7 +2268,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
@@ -2189,6 +2411,7 @@ checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.6.0",
  "block2",
+ "dispatch",
  "libc",
  "objc2",
 ]
@@ -2373,6 +2596,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "os_pipe"
@@ -2623,6 +2856,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2637,7 +2881,7 @@ dependencies = [
  "base64 0.21.5",
  "indexmap 2.1.0",
  "line-wrap",
- "quick-xml",
+ "quick-xml 0.31.0",
  "serde",
  "time",
 ]
@@ -2653,6 +2897,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2737,6 +2996,15 @@ name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
 ]
@@ -2960,6 +3228,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af382a047821a08aa6bfc09ab0d80ff48d45d8726f7cd8e44891f7cb4a4278e"
+dependencies = [
+ "ashpd",
+ "block2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,15 +3267,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3059,6 +3350,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.94",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3406,6 +3703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3718,6 +4021,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b59fd750551b1066744ab956a1cd6b1ea3e1b3763b0b9153ac27a044d596426"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.9",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1edf18000f02903a7c2e5997fb89aca455ecbc0acc15c6535afbb883be223"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.9",
+ "toml 0.8.2",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3980,6 +4324,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
 ]
 
@@ -4261,6 +4606,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4520,6 +4876,66 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
+dependencies = [
+ "bitflags 2.6.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.36.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5082,6 +5498,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "zbus"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8e3d6ae3342792a6cc2340e4394334c7402f3d793b390d2c5494a4032b3030"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "derivative",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a3e850ff1e7217a3b7a07eba90d37fe9bb9e89a310f718afcde5885ca9b6d7"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
 name = "zeromq"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,4 +5591,42 @@ dependencies = [
  "tokio",
  "tokio-util",
  "uuid",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e09e8be97d44eeab994d752f341e67b3b0d80512a8b315a0671d47232ef1b65"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "url",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a5857e2856435331636a9fbb415b09243df4521a267c5bedcd5289b4d5799e"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bedb16a193cc12451873fee2a1bc6550225acece0e36f333e68326c73c8172"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ serde_urlencoded = "0.7.1"
 sha2 = "0.10.8"
 sysinfo = "0.30.3"
 tauri = { version = "2.0.4", features = ["devtools", "macos-private-api"] }
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 tauri-plugin-shell = "2.2.0"
 thiserror = "1.0.57"
 time = { version = "0.3.36", features = ["serde", "serde-human-readable"] }
@@ -31,8 +33,8 @@ tokio-util = "0.7.11"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 ts-rs = { version = "10.1.0", features = [
-    "no-serde-warnings",
-    "serde-json-impl",
+  "no-serde-warnings",
+  "serde-json-impl",
 ] }
 url = "2.5.0"
 uuid = { version = "1.7.0", features = ["v4"] }
@@ -44,9 +46,9 @@ objc = "0.2.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58.0", features = [
-    "Win32_Graphics_Dwm",
-    "Win32_Foundation",
-    "Win32_UI_Controls",
+  "Win32_Graphics_Dwm",
+  "Win32_Foundation",
+  "Win32_UI_Controls",
 ] }
 winver = "1.0.0"
 

--- a/src-tauri/capabilities/jute-window.json
+++ b/src-tauri/capabilities/jute-window.json
@@ -2,13 +2,17 @@
   "identifier": "jute-window",
   "description": "Capability for the Jute webviews",
   "local": true,
-  "windows": ["jute-window-*"],
+  "windows": [
+    "jute-window-*"
+  ],
   "permissions": [
     "core:default",
     "core:window:allow-create",
     "core:window:allow-center",
     "core:window:allow-request-user-attention",
     "core:window:allow-start-dragging",
-    "shell:default"
+    "shell:default",
+    "fs:default",
+    "dialog:default"
   ]
 }

--- a/src-tauri/capabilities/jute-window.json
+++ b/src-tauri/capabilities/jute-window.json
@@ -2,9 +2,7 @@
   "identifier": "jute-window",
   "description": "Capability for the Jute webviews",
   "local": true,
-  "windows": [
-    "jute-window-*"
-  ],
+  "windows": ["jute-window-*"],
   "permissions": [
     "core:default",
     "core:window:allow-create",

--- a/src-tauri/src/backend/notebook.rs
+++ b/src-tauri/src/backend/notebook.rs
@@ -29,13 +29,13 @@ pub struct Notebook {
 }
 
 impl Notebook {
-    // Loads a notebook from a JSON string.
+    /// Loads a notebook from a JSON string.
     pub fn load_from_str(s: &str) -> Result<Self, crate::Error> {
         let notebook: Notebook = serde_json::from_str(s).map_err(crate::Error::from)?;
         Ok(notebook)
     }
 
-    // Loads a notebook from a file path.
+    /// Loads a notebook from a file path.
     pub fn load_from_path(path: &str) -> Result<Self, crate::Error> {
         let s = std::fs::read_to_string(path)?;
         Self::load_from_str(&s)

--- a/src-tauri/src/backend/notebook.rs
+++ b/src-tauri/src/backend/notebook.rs
@@ -28,6 +28,20 @@ pub struct Notebook {
     pub cells: Vec<Cell>,
 }
 
+impl Notebook {
+    // Loads a notebook from a JSON string.
+    pub fn load_from_str(s: &str) -> Result<Self, crate::Error> {
+        let notebook: Notebook = serde_json::from_str(s).map_err(crate::Error::from)?;
+        Ok(notebook)
+    }
+
+    // Loads a notebook from a file path.
+    pub fn load_from_path(path: &str) -> Result<Self, crate::Error> {
+        let s = std::fs::read_to_string(path)?;
+        Self::load_from_str(&s)
+    }
+}
+
 /// Root-level metadata for the notebook.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, TS)]
 pub struct NotebookMetadata {

--- a/src-tauri/src/backend/notebook.rs
+++ b/src-tauri/src/backend/notebook.rs
@@ -37,7 +37,8 @@ impl Notebook {
 
     /// Loads a notebook from a file path.
     pub fn load_from_path(path: &str) -> Result<Self, crate::Error> {
-        let s = std::fs::read_to_string(path)?;
+        let s = std::fs::read_to_string(path).map_err(crate::Error::Filesystem)?;
+
         Self::load_from_str(&s)
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,14 @@ pub enum Error {
     /// Error originating from ZeroMQ.
     #[error("zeromq: {0}")]
     Zmq(#[from] zeromq::ZmqError),
+
+    // Error originating from serde_json.
+    #[error("serde_json error: {0}")]
+    SerdeJson(#[from] serde_json::error::Error),
+
+    // Error interacting with the filesystem.
+    #[error("filesystem error: {0}")]
+    Filesystem(#[from] std::io::Error),
 }
 
 impl serde::Serialize for Error {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,11 +40,11 @@ pub enum Error {
     #[error("zeromq: {0}")]
     Zmq(#[from] zeromq::ZmqError),
 
-    // Error originating from serde_json.
+    /// Error originating from serde_json.
     #[error("serde_json error: {0}")]
     SerdeJson(#[from] serde_json::error::Error),
 
-    // Error interacting with the filesystem.
+    /// Error interacting with the filesystem.
     #[error("filesystem error: {0}")]
     Filesystem(#[from] std::io::Error),
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,7 +46,7 @@ pub enum Error {
 
     /// Error interacting with the filesystem.
     #[error("filesystem error: {0}")]
-    Filesystem(#[from] std::io::Error),
+    Filesystem(io::Error),
 }
 
 impl serde::Serialize for Error {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,4 @@
-import { open } from '@tauri-apps/plugin-dialog';
-
+import { open } from "@tauri-apps/plugin-dialog";
 import { ArrowRight } from "lucide-react";
 import { Link, useLocation } from "wouter";
 
@@ -32,11 +31,14 @@ export default function HomePage() {
         ))}
       </div>
 
-      <button className="w-fit flex items-center gap-2" onClick={async () => {
-        const file = await open({ multiple: false, directory: false });
-        if (file)
-          navigate("/notebook?" + new URLSearchParams({ path: file }));
-      }}>
+      <button
+        className="flex w-fit items-center gap-2"
+        onClick={async () => {
+          const file = await open({ multiple: false, directory: false });
+          if (file)
+            navigate("/notebook?" + new URLSearchParams({ path: file }));
+        }}
+      >
         Open a notebook <ArrowRight size="1em" />
       </button>
     </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,7 @@
-import { Link } from "wouter";
+import { open } from '@tauri-apps/plugin-dialog';
+
+import { ArrowRight } from "lucide-react";
+import { Link, useLocation } from "wouter";
 
 const sampleNotebookNames = [
   "~/Numpy_starter.ipynb",
@@ -7,6 +10,7 @@ const sampleNotebookNames = [
 ];
 
 export default function HomePage() {
+  const [, navigate] = useLocation();
   return (
     <div className="mt-20 flex flex-col gap-4 px-8 font-light">
       <h1 className="mt-2 text-5xl">Welcome to Jute</h1>
@@ -27,6 +31,14 @@ export default function HomePage() {
           </Link>
         ))}
       </div>
+
+      <button className="w-fit flex items-center gap-2" onClick={async () => {
+        const file = await open({ multiple: false, directory: false });
+        if (file)
+          navigate("/notebook?" + new URLSearchParams({ path: file }));
+      }}>
+        Open a notebook <ArrowRight size="1em" />
+      </button>
     </div>
   );
 }

--- a/src/pages/NotebookPage.tsx
+++ b/src/pages/NotebookPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useSearch } from "wouter";
 
 import { Notebook, NotebookContext } from "@/stores/notebook";
@@ -10,23 +10,6 @@ export default function NotebookPage() {
   const { path } = Object.fromEntries(new URLSearchParams(useSearch()));
   // Single mutable object that is shared between all parts of the notebook.
   const notebook = useMemo(() => new Notebook(path), [path]);
-
-  useEffect(() => {
-    notebook.addCell(`print("Hello, world!")`);
-    notebook.addCell(`for i in range(100):
-    if i % 15 == 0:
-        print("FizzBuzz")
-    elif i % 3 == 0:
-        print("Fizz")
-    elif i % 5 == 0:
-        print("Buzz")
-    else:
-        print(i)`);
-    notebook.addCell(`import matplotlib.pyplot as plt
-import numpy as np
-
-plt.plot(np.random.normal(size=(400,)).cumsum())`);
-  }, [notebook]);
 
   return (
     <main className="absolute inset-0 bg-white">

--- a/src/stores/notebook.ts
+++ b/src/stores/notebook.ts
@@ -141,7 +141,8 @@ export class Notebook {
       if (e instanceof Error || typeof e === "string") {
         this.state.error = e.toString();
       } else {
-        this.state.error = "An unknown error occurred while loading the notebook.";
+        this.state.error =
+          "An unknown error occurred while loading the notebook.";
       }
     }
   }

--- a/src/stores/notebook.ts
+++ b/src/stores/notebook.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { StoreApi, createStore } from "zustand";
 import { immer } from "zustand/middleware/immer";
 
-import type { RunCellEvent, Notebook as NotebookType } from "@/bindings";
+import type { Notebook as NotebookType, RunCellEvent } from "@/bindings";
 
 type NotebookStore = NotebookStoreState & NotebookStoreActions;
 
@@ -112,14 +112,19 @@ export class Notebook {
   }
 
   async loadNotebook() {
-    const notebook = await invoke<NotebookType>("get_notebook", { path: this.path });
+    const notebook = await invoke<NotebookType>("get_notebook", {
+      path: this.path,
+    });
 
     this.state.cellIds = notebook.cells.map((cell) => cell.id);
 
     this.state.cells = notebook.cells.reduce((acc, cell) => {
       this.refs.set(cell.id, {});
       acc[cell.id] = {
-        initialText: typeof cell.source === "string" ? cell.source : cell.source.join("\n"),
+        initialText:
+          typeof cell.source === "string"
+            ? cell.source
+            : cell.source.join("\n"),
         output: undefined,
       };
       return acc;

--- a/src/stores/notebook.ts
+++ b/src/stores/notebook.ts
@@ -103,7 +103,6 @@ export class Notebook {
           set((state) => {
             state.cellIds = notebook.cells.map((cell) => cell.id);
             state.cells = notebook.cells.reduce((acc, cell) => {
-              this.refs.set(cell.id, {});
               acc[cell.id] = {
                 initialText:
                   typeof cell.source === "string"
@@ -152,13 +151,19 @@ export class Notebook {
       });
 
       this.state.loadNotebook(notebook);
+      this.refs = notebook.cells.reduce((acc, cell) => {
+        acc.set(cell.id, {});
+        return acc;
+      }, this.refs);
     } catch (e: unknown) {
       this.state.setIsLoading(false);
 
       if (e instanceof Error || typeof e === "string") {
         this.state.setError(e.toString());
       } else {
-        this.state.setError("An unknown error occurred while loading the notebook.");
+        this.state.setError(
+          "An unknown error occurred while loading the notebook.",
+        );
       }
     }
   }

--- a/src/ui/notebook/NotebookCells.tsx
+++ b/src/ui/notebook/NotebookCells.tsx
@@ -72,6 +72,15 @@ export default function NotebookCells() {
   const notebook = useNotebook();
   const cellIds = useStore(notebook.store, (state) => state.cellIds);
   const cells = useStore(notebook.store, (state) => state.cells);
+  const isLoading = useStore(notebook.store, (state) => state.isLoading);
+
+  if (isLoading)
+    // TODO: add a better loading state
+    return (
+      <div className="relative p-8 px-14">
+        <div>Loading...</div>
+      </div>
+    );
 
   return (
     <div className="relative py-8">

--- a/src/ui/notebook/NotebookView.tsx
+++ b/src/ui/notebook/NotebookView.tsx
@@ -2,9 +2,13 @@ import { useNotebook } from "@/stores/notebook";
 
 import NotebookCells from "./NotebookCells";
 import NotebookLocation from "./NotebookLocation";
+import { useStore } from "zustand";
+import { Error } from "@/ui/shared/Error";
 
 export default function NotebookView() {
   const notebook = useNotebook();
+
+  const error = useStore(notebook.store, (state) => state.error);
 
   return (
     <div className="grid h-full grid-cols-[1fr,200px] overflow-y-auto">
@@ -13,7 +17,12 @@ export default function NotebookView() {
           directory={notebook.directory}
           filename={notebook.filename}
         />
-        <NotebookCells />
+
+        {error ? (
+          <Error error={error} />
+        ) : (
+          <NotebookCells />
+        )}
       </div>
       <div
         className="border-l border-gray-200 bg-gray-100"

--- a/src/ui/notebook/NotebookView.tsx
+++ b/src/ui/notebook/NotebookView.tsx
@@ -1,9 +1,10 @@
+import { useStore } from "zustand";
+
 import { useNotebook } from "@/stores/notebook";
+import { Error } from "@/ui/shared/Error";
 
 import NotebookCells from "./NotebookCells";
 import NotebookLocation from "./NotebookLocation";
-import { useStore } from "zustand";
-import { Error } from "@/ui/shared/Error";
 
 export default function NotebookView() {
   const notebook = useNotebook();
@@ -18,11 +19,7 @@ export default function NotebookView() {
           filename={notebook.filename}
         />
 
-        {error ? (
-          <Error error={error} />
-        ) : (
-          <NotebookCells />
-        )}
+        {error ? <Error error={error} /> : <NotebookCells />}
       </div>
       <div
         className="border-l border-gray-200 bg-gray-100"

--- a/src/ui/shared/Error.tsx
+++ b/src/ui/shared/Error.tsx
@@ -3,14 +3,12 @@ import { Link } from "wouter";
 
 type Props = {
   error?: string;
-}
+};
 
 export function Error(props: Props) {
   return (
-    <div className="flex flex-col gap-2 items-center justify-center w-full h-full">
-      <h3 className="text-3xl">
-        An error occured.
-      </h3>
+    <div className="flex h-full w-full flex-col items-center justify-center gap-2">
+      <h3 className="text-3xl">An error occured.</h3>
 
       <div className="text-l">
         {props.error || "An unknown error occurred."}

--- a/src/ui/shared/Error.tsx
+++ b/src/ui/shared/Error.tsx
@@ -1,0 +1,27 @@
+import { ArrowLeft } from "lucide-react";
+import { Link } from "wouter";
+
+type Props = {
+  error?: string;
+}
+
+export function Error(props: Props) {
+  return (
+    <div className="flex flex-col gap-2 items-center justify-center w-full h-full">
+      <h3 className="text-3xl">
+        An error occured.
+      </h3>
+
+      <div className="text-l">
+        {props.error || "An unknown error occurred."}
+      </div>
+
+      <Link to="/">
+        <button className="mt-4 flex items-center gap-2">
+          <ArrowLeft size="1em" />
+          Go back to home
+        </button>
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
This allows users to open notebook from the home page.

When opening a notebook, the UI uses a native file-picker dialog. The UI then reroutes the user to the URL corresponding to the selected notebook, where the path is passed to the Tauri application to be opened and serialized into our `Notebook` object.

There's some delay in reading the file from disk (because we immediately route to the notebook path and _then_ open/serialize the file). There may be better ways to do this but this feels like a reasonable first pass.

Note that it currently doesn't load outputs if they're saved to the file, because we currently use two different types. I'll follow this up with consolidating the typing so we can load outputs too.